### PR TITLE
Adiciona testes para encode e decode BMN

### DIFF
--- a/tests/test_bmn.py
+++ b/tests/test_bmn.py
@@ -1,0 +1,27 @@
+import pytest
+
+from bmn import encode_bmn, decode_bmn
+
+
+def test_encode_decode_round_trip():
+    matrix = [
+        [0, 1, 0],
+        [1, 0, 1],
+        [0, 1, 0],
+    ]
+    bmn_string = encode_bmn(matrix)
+    decoded = decode_bmn(bmn_string)
+    assert decoded == matrix
+
+
+def test_decode_bmn_invalid_dimension_characters():
+    with pytest.raises(ValueError):
+        decode_bmn("3xa:AA==")
+
+
+def test_decode_bmn_inconsistent_dimensions():
+    matrix = [[1, 0], [0, 1]]
+    bmn_string = encode_bmn(matrix)
+    tampered = bmn_string.replace("2x2", "3x3")
+    with pytest.raises(IndexError):
+        decode_bmn(tampered)


### PR DESCRIPTION
## Resumo
- Garante que `decode_bmn(encode_bmn(matrix))` retorna a matriz original.
- Adiciona verificações de erro para caracteres inválidos nas dimensões.
- Testa falha ao decodificar quando as dimensões não batem com os dados codificados.

## Testes
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689608a90f1c8323a643ab3e449dfd83